### PR TITLE
Fix env vars and schema refs

### DIFF
--- a/.env
+++ b/.env
@@ -2,5 +2,5 @@ MONGODB_URI=mongodb+srv://theigniteai:flxDeKWM6KImvDyd@accent-changer.k4aibsh.mo
 JWT_SECRET=mUzaSAl@310896kAp@dIaa!!
 OPENAI_KEY=your_openai_key
 ELEVENLABS_API_KEY=sk_65a242103145e88b070f5f5d2f86b0567e9a8b71d6dee825
-GOOGLE_APPLICATION_CREDENTIALS=backend/gcp/accentshift-key.json
+GOOGLE_APPLICATION_CREDENTIALS=gcp/accentshift-bb444e45fc45.json
 

--- a/config/db.js
+++ b/config/db.js
@@ -2,7 +2,7 @@ import mongoose from 'mongoose'
 
 const connectDB = async () => {
   try {
-    const conn = await mongoose.connect(process.env.MONGO_URI)
+    const conn = await mongoose.connect(process.env.MONGODB_URI)
     console.log(`MongoDB Connected: ${conn.connection.host}`)
   } catch (error) {
     console.error(`Error: ${error.message}`)

--- a/controllers/aiAssistantController.js
+++ b/controllers/aiAssistantController.js
@@ -50,7 +50,7 @@ export const generateAIResponse = async (req, res) => {
       },
       {
         headers: {
-          Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+          Authorization: `Bearer ${process.env.OPENAI_KEY}`,
         },
       }
     )

--- a/controllers/aiAssistantController.js
+++ b/controllers/aiAssistantController.js
@@ -16,14 +16,12 @@ const __dirname = path.dirname(__filename)
 let client
 
 try {
-  const credentialsJson = process.env.GOOGLE_APPLICATION_CREDENTIALS_JSON
-  if (!credentialsJson) {
-    throw new Error("Missing GOOGLE_APPLICATION_CREDENTIALS_JSON in ENV.")
+  const credentialsPath = process.env.GOOGLE_APPLICATION_CREDENTIALS
+  if (!credentialsPath) {
+    throw new Error("Missing GOOGLE_APPLICATION_CREDENTIALS in ENV.")
   }
 
-  const credentials = JSON.parse(credentialsJson)
-
-  client = new TextToSpeechClient({ credentials })
+  client = new TextToSpeechClient({ keyFilename: credentialsPath })
 } catch (err) {
   console.error("❌ GCP TTS Client Init Error:", err.message)
 }

--- a/models/AIAgentSettings.js
+++ b/models/AIAgentSettings.js
@@ -1,7 +1,7 @@
 import mongoose from "mongoose";
 
 const AIAgentSettingsSchema = new mongoose.Schema({
-  userId: { type: mongoose.Schema.Types.ObjectId, required: true }, // <-- fix here
+  userId: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
   prompt: { type: String, required: true },
   voice: { type: String, default: "eleven_en_us_male" },
   assignedNumber: { type: String, required: true },

--- a/models/CallLog.js
+++ b/models/CallLog.js
@@ -1,7 +1,7 @@
 import mongoose from "mongoose";
 
 const CallLogSchema = new mongoose.Schema({
-  userId: { type: mongoose.Schema.Types.ObjectId, required: true }, // <-- fix here too
+  userId: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
   from: String,
   to: String,
   userSpeech: String,

--- a/routes/aiAssistantRoutes.js
+++ b/routes/aiAssistantRoutes.js
@@ -38,7 +38,7 @@ router.post('/respond', async (req, res) => {
       },
       {
         headers: {
-          Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+          Authorization: `Bearer ${process.env.OPENAI_KEY}`,
         },
       }
     );

--- a/routes/aiAssistantRoutes.js
+++ b/routes/aiAssistantRoutes.js
@@ -15,7 +15,7 @@ const __dirname = path.dirname(__filename);
 
 // Google TTS client (fallback if needed)
 const gcpClient = new TextToSpeechClient({
-  credentials: JSON.parse(process.env.GOOGLE_APPLICATION_CREDENTIALS_JSON),
+  keyFilename: process.env.GOOGLE_APPLICATION_CREDENTIALS,
 });
 
 // POST /ai/respond

--- a/server.js
+++ b/server.js
@@ -42,7 +42,7 @@ app.get('/', (req, res) => {
 });
 
 // ✅ MongoDB Connection
-mongoose.connect(process.env.MONGO_URI, {
+mongoose.connect(process.env.MONGODB_URI, {
   useNewUrlParser: true,
   useUnifiedTopology: true
 })

--- a/services/openaiService.js
+++ b/services/openaiService.js
@@ -2,7 +2,7 @@
 import OpenAI from "openai";
 
 const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
+  apiKey: process.env.OPENAI_KEY,
 });
 
 export const getOpenAIResponse = async (userPrompt, userInput) => {

--- a/services/ttsService.js
+++ b/services/ttsService.js
@@ -10,7 +10,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const client = new TextToSpeechClient();
-const ELEVEN_API_KEY = process.env.ELEVEN_API_KEY;
+const ELEVEN_API_KEY = process.env.ELEVENLABS_API_KEY;
 const BACKEND_URL = process.env.BACKEND_URL;
 
 export const generateTTS = async (text, voiceId) => {

--- a/services/ttsService.js
+++ b/services/ttsService.js
@@ -35,9 +35,9 @@ export const generateTTS = async (text, voiceId) => {
     );
 
     const filename = `audio_${uuidv4()}.mp3`;
-    const filePath = path.join(__dirname, "..", "public", filename);
+    const filePath = path.join(__dirname, "..", "output", filename);
     fs.writeFileSync(filePath, response.data);
-    return `${BACKEND_URL}/${filename}`;
+    return `${BACKEND_URL}/output/${filename}`;
   } catch (err) {
     console.warn("❗ ElevenLabs failed, using Google TTS fallback:", err.message);
 
@@ -54,8 +54,8 @@ export const generateTTS = async (text, voiceId) => {
 
     const [response] = await client.synthesizeSpeech(request);
     const filename = `google_audio_${uuidv4()}.mp3`;
-    const filePath = path.join(__dirname, "..", "public", filename);
+    const filePath = path.join(__dirname, "..", "output", filename);
     fs.writeFileSync(filePath, response.audioContent);
-    return `${BACKEND_URL}/${filename}`;
+    return `${BACKEND_URL}/output/${filename}`;
   }
 };

--- a/utils/transcriber.js
+++ b/utils/transcriber.js
@@ -36,7 +36,7 @@ export const transcribeAudio = async (recordingUrl) => {
       formData,
       {
         headers: {
-          Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+          Authorization: `Bearer ${process.env.OPENAI_KEY}`,
           ...formData.getHeaders(),
         },
       }


### PR DESCRIPTION
## Summary
- fix mismatched env var names for MongoDB, OpenAI, and ElevenLabs
- add `ref: "User"` to `userId` fields in models

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68403165e5048322a8ddb420d544fbd6